### PR TITLE
Rework commands and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,26 @@ https://pypi.org/project/keyboard/
 
 Utility.py
 Process tags from IRCv3
+
+## Cheer command configuration
+
+Cheer commands are composed of sequences of actions. An action is a low-level 'thing'
+and can be anything, from injecting key presses to running any other code. Actions must
+map to code defined in `actions.py`, identified by the `kind` field in the configs.
+
+The cheer command config is set by the `currentGameConfig` filename in the `cfg.py` file.
+
+The expected format is:
+
+```yaml
+commands:
+  - name: name of command
+    message: message sent to chat when command is run
+    cost: 100 # normal bits cost
+    discount: 50 # discount bits cost, for subscribers
+    actions:
+      - kind: keypress # this must map to actual actions defined in actions.py
+        args: [a] # oneliner form of list is used here for brevity.
+        # args that get passed to the action when it's run.
+  - name: etc...
+```

--- a/actions.py
+++ b/actions.py
@@ -1,0 +1,98 @@
+import random
+import threading
+import time
+from typing import List, ClassVar, Dict, Type
+
+import attr
+import keyboard
+
+_registry: Dict[str, Type['Action']] = {}
+
+
+@attr.s(auto_attribs=True, slots=True)
+class Action:
+    """
+    A single action, like pressing a key, waiting, etc. To define an actual action, you
+    must subclass this and implement the run method. The 'args' will be as loaded from
+    the configuration file.
+    """
+    kind: ClassVar[str]
+    _args: List = attr.ib(factory=list)
+
+    @classmethod
+    def from_config(cls, config: Dict) -> 'Action':
+        return _registry[config['kind']](args=config['args'])
+
+    def run(self):
+        raise NotImplementedError
+
+
+class KeyPress(Action):
+    kind = 'keypress'
+
+    def run(self):
+        key = self._args[0]
+        if len(self._args) == 2:
+            exec(f'keyboard.press("{key}")')
+            time.sleep(float(self._args[1]))
+            exec(f'keyboard.release("{key}")')
+        else:
+            exec(f'keyboard.send("{key}")')
+
+
+class Wait(Action):
+    kind = 'wait'
+
+    def run(self):
+        time.sleep(float(self._args[0]))
+
+
+class Click(Action):
+    kind = 'click'
+
+    def run(self):
+        button = self._args[0]
+        if len(self._args) == 2:
+            exec(f'mouse.press("{button}")')
+            time.sleep(float(self._args[1]))
+            exec(f'mouse.release("{button}")')
+        else:
+            exec(f'mouse.click("{button}")')
+
+
+class WackyWasd(Action):
+    kind = 'wackywasd'
+
+    def run(self):
+        wasd = list('wasd')
+        new_wasd = []
+
+        i = 0
+        while not i == 4:
+            print(i)
+            print(wasd[i])
+            temp = set(wasd)
+            temp.remove(wasd[i])
+            diff = [x for x in temp if x not in new_wasd]
+            if i == 3 and len(diff) > 1:
+                print("avoiding same final key")
+                new_wasd.append(new_wasd[2])
+                new_wasd[2] = wasd[3]
+            else:
+                new_wasd.append(random.choice(diff))
+            i = i + 1
+
+        print(wasd)
+        print(new_wasd)
+        for a, b in zip(wasd, new_wasd):
+            exec(f'keyboard.remap_key("{a}", "{b}")')
+            print(f'{a}: {b}')
+
+        def reset():
+            time.sleep(float(self._args[0]))
+            keyboard.unhook_all()
+        threading.Thread(target=reset).start()
+
+
+for clz in Action.__subclasses__():
+    _registry[clz.kind] = clz

--- a/actions.py
+++ b/actions.py
@@ -102,7 +102,7 @@ class WackyWasd(Action):
             temp = set(wasd)
             temp.remove(wasd[i])
             diff = [x for x in temp if x not in new_wasd]
-            if i == 3 and len(diff) > 1:
+            if i == 3 and len(diff) < 1:
                 print("avoiding same final key")
                 new_wasd.append(new_wasd[2])
                 new_wasd[2] = wasd[3]

--- a/actions.py
+++ b/actions.py
@@ -6,6 +6,8 @@ from typing import List, ClassVar, Dict, Type
 import attr
 import keyboard
 
+from special_types import Chatter
+
 _registry: Dict[str, Type['Action']] = {}
 
 
@@ -29,9 +31,15 @@ class Action:
         return a
 
     def validate(self):
+        """ Optional method to run during setup to validate/process args. """
         pass
 
-    def run(self):
+    def run(self, chat: Chatter):
+        """
+        Runs the action.
+        :param chat: A function reference to send a chat message. Generally not needed,
+            but useful for timed things that run in threads (eg. wacky WASD).
+        """
         raise NotImplementedError
 
 
@@ -45,7 +53,7 @@ class KeyPress(Action):
         if len(self._args) == 2:
             self.duration_s = float(self._args[1])
 
-    def run(self):
+    def run(self, chat):
         if self.duration_s > 0:
             exec(f'keyboard.press("{self.key}")')
             time.sleep(self.duration_s)
@@ -61,7 +69,7 @@ class Wait(Action):
     def validate(self):
         self.duration_s = float(self._args[0])
 
-    def run(self):
+    def run(self, chat):
         time.sleep(self.duration_s)
 
 
@@ -75,7 +83,7 @@ class Click(Action):
         if len(self._args) == 2:
             self.duration_s = float(self._args[1])
 
-    def run(self):
+    def run(self, chat):
         if self.duration_s > 0:
             exec(f'mouse.press("{self.button}")')
             time.sleep(self.duration_s)
@@ -91,7 +99,7 @@ class WackyWasd(Action):
     def validate(self):
         self.duration_s = float(self._args[0])
 
-    def run(self):
+    def run(self, chat):
         wasd = list('wasd')
         new_wasd = []
 
@@ -119,6 +127,7 @@ class WackyWasd(Action):
         def reset():
             time.sleep(self.duration_s)
             keyboard.unhook_all()
+            chat('The wacky WASD timer has ended.')
         threading.Thread(target=reset).start()
 
 

--- a/cfg.py
+++ b/cfg.py
@@ -3,11 +3,11 @@ import yaml
 import cmds
 
 #game
-currentGameConfig = "pubg.csv"
+currentGameConfig = "pubg.yml"
 
 #channel point identifiers - when a user redeems channel points, the channel point will have an identifier (e.g. "b3df3074-eb94-4f44-811a-1815835edfdd")
 channelPoint1 = ""
 
 with open(currentGameConfig) as f:
-    config = yaml.load(f)
+    config = yaml.safe_load(f)
     cmds.from_config(config)

--- a/cfg.py
+++ b/cfg.py
@@ -1,40 +1,13 @@
-import csv
+import yaml
+
+import cmds
 
 #game
 currentGameConfig = "pubg.csv"
 
-#idle time for commands that require a time out
-idleTime = 10
-
 #channel point identifiers - when a user redeems channel points, the channel point will have an identifier (e.g. "b3df3074-eb94-4f44-811a-1815835edfdd")
 channelPoint1 = ""
 
-#WASD - hard-coded bit costs for Wacky Wasd function
-subWASD = 333
-WASD = 666
-
-#import commands
-cost = []
-discount = []
-description = []
-kind = []
-action = []
-actionDetail = []
-duration = []
-action2 = []
-
-row_count = 0
-
-with open(currentGameConfig) as csvDataFile:
-    csvReader = csv.reader(csvDataFile)
-    for row in csvReader:
-        cost.append(row[0])
-        discount.append(row[1])
-        description.append(row[2])
-        kind.append(row[3])
-        action.append(row[4])
-        actionDetail.append(row[5])
-        duration.append(row[6])
-        action2.append(row[7])
 with open(currentGameConfig) as f:
-    row_count = sum(1 for line in f)	
+    config = yaml.load(f)
+    cmds.from_config(config)

--- a/cmds.py
+++ b/cmds.py
@@ -1,0 +1,91 @@
+import random
+from typing import Dict, List, Union, Optional
+
+import attr
+
+from actions import Action
+
+_registry: Dict[Union[int, str], 'Command'] = {}
+_discounts: Dict[int, 'Command'] = {}
+
+
+@attr.s(auto_attribs=True, slots=True, frozen=True)
+class Command:
+    name: str
+    message: str
+    cost: int
+    discount: int
+    _actions: List[Action] = attr.ib(factory=list)
+
+    @classmethod
+    def from_config(cls, config: Dict) -> 'Command':
+        actions = []
+        for cfg in config['actions']:
+            actions.append(Action.from_config(cfg))
+        return Command(
+            config['name'],
+            config['message'],
+            config['cost'],
+            config['discount'],
+            actions,
+        )
+
+    def run(self):
+        print(f'running {self.name}')
+        for a in self._actions:
+            a.run()
+
+
+def from_config(config: Dict) -> Dict[int, Command]:
+    """
+    :param config: Parsed dictionary from YAML config load.
+    :return: A dictionary of parsed commands keyed by the bits cost and discount cost.
+        Meant for quick lookup in the bot message processing loop.
+    """
+    _registry.clear()
+    _discounts.clear()
+    for cfg in config['commands']:
+        c = Command.from_config(cfg)
+        if c.cost in _registry:
+            raise ValueError(f'Bits cost conflict: {c.cost}')
+        if c.discount in _discounts:
+            raise ValueError(f'Discount conflict: {c.discount}')
+        if c.name in _registry:
+            raise ValueError(f'Command name conflict: {c.name}')
+        _registry[c.cost] = c
+        _discounts[c.discount] = c
+        _registry[c.name] = c
+    print(_registry)
+    return _registry
+
+
+def run(x: Union[str, int], discount=False) -> Command:
+    """
+    Runs a command. If the input is a string, it'll do a lookup based on the name. If
+    it's an integer, it'll do a lookup based on bits/discount cost.
+    :returns: The called command, if one was found. Else None.
+    """
+    if discount:
+        cmd = _discounts.get(x)
+    else:
+        cmd = _registry.get(x)
+    if cmd is not None:
+        cmd.run()
+    return cmd
+
+
+def get_nth(i: int) -> Optional[Command]:
+    """ Gets the nth command. Used during stream setup/testing. """
+    # Double it because we're adding the commands multiple times for faster lookups
+    i *= 2
+    if not (0 <= i < len(_registry)):
+        print('COMMAND NUMBER EXCEEDS THE MAX')
+        return None
+    return list(_registry.values())[i]
+
+
+def run_random() -> Command:
+    """ Runs a random command. Returns the command. """
+    cmd = random.choice(list(_registry.values()))
+    cmd.run()
+    return cmd

--- a/cmds.py
+++ b/cmds.py
@@ -1,5 +1,5 @@
 import random
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Union, Optional, Callable
 
 import attr
 
@@ -36,7 +36,7 @@ class Command:
             a.run()
 
 
-def from_config(config: Dict) -> Dict[int, Command]:
+def from_config(config: Dict) -> Dict[Union[str, int], Command]:
     """
     :param config: Parsed dictionary from YAML config load.
     :return: A dictionary of parsed commands keyed by the bits cost and discount cost.
@@ -59,10 +59,11 @@ def from_config(config: Dict) -> Dict[int, Command]:
     return _registry
 
 
-def run(x: Union[str, int], discount=False) -> Command:
+def run(x: Union[str, int], discount: bool = False) -> Command:
     """
     Runs a command. If the input is a string, it'll do a lookup based on the name. If
     it's an integer, it'll do a lookup based on bits/discount cost.
+    :param discount: Whether to match bits amounts to discounted values.
     :returns: The called command, if one was found. Else None.
     """
     if discount:

--- a/cmds.py
+++ b/cmds.py
@@ -1,9 +1,10 @@
 import random
-from typing import Dict, List, Union, Optional, Callable
+from typing import Dict, List, Union, Optional
 
 import attr
 
 from actions import Action
+from special_types import Chatter
 
 _registry: Dict[Union[int, str], 'Command'] = {}
 _discounts: Dict[int, 'Command'] = {}
@@ -30,10 +31,15 @@ class Command:
             actions,
         )
 
-    def run(self):
+    def run(self, chat: Chatter):
+        """
+        Runs the command.
+        :param chat: A function reference to send a message to chat.
+        """
         print(f'running {self.name}')
+        chat(self.message)
         for a in self._actions:
-            a.run()
+            a.run(chat)
 
 
 def from_config(config: Dict) -> Dict[Union[str, int], Command]:
@@ -59,11 +65,14 @@ def from_config(config: Dict) -> Dict[Union[str, int], Command]:
     return _registry
 
 
-def run(x: Union[str, int], discount: bool = False) -> Command:
+def run(x: Union[str, int], chat: Chatter, discount: bool = False) -> Command:
     """
     Runs a command. If the input is a string, it'll do a lookup based on the name. If
     it's an integer, it'll do a lookup based on bits/discount cost.
+    :param x: Lookup value or string. If a number, looks up the command associated with
+        the bits cost. If a string, looks up the command name.
     :param discount: Whether to match bits amounts to discounted values.
+    :param chat: A function reference to send a message to chat.
     :returns: The called command, if one was found. Else None.
     """
     if discount:
@@ -71,24 +80,26 @@ def run(x: Union[str, int], discount: bool = False) -> Command:
     else:
         cmd = _registry.get(x)
     if cmd is not None:
-        cmd.run()
+        cmd.run(chat)
     elif isinstance(x, str):  # When a command name was passed, we warn if nothing was found
         print(f'WARNING: command not found! {x}')
     return cmd
 
 
-def get_nth(i: int) -> Optional[Command]:
-    """ Gets the nth command. Used during stream setup/testing. """
+def run_nth(i: int, chat: Chatter) -> Optional[Command]:
+    """ Runs the nth command. Used during stream setup/testing. """
     # Double it because we're adding the commands multiple times for faster lookups
     i *= 2
     if not (0 <= i < len(_registry)):
         print('COMMAND NUMBER EXCEEDS THE MAX')
         return None
-    return list(_registry.values())[i]
+    cmd = list(_registry.values())[i]
+    cmd.run(chat)
+    return cmd
 
 
-def run_random() -> Command:
+def run_random(chat: Chatter) -> Command:
     """ Runs a random command. Returns the command. """
     cmd = random.choice(list(_registry.values()))
-    cmd.run()
+    cmd.run(chat)
     return cmd

--- a/cmds.py
+++ b/cmds.py
@@ -71,6 +71,8 @@ def run(x: Union[str, int], discount=False) -> Command:
         cmd = _registry.get(x)
     if cmd is not None:
         cmd.run()
+    elif isinstance(x, str):  # When a command name was passed, we warn if nothing was found
+        print(f'WARNING: command not found! {x}')
     return cmd
 
 

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ TODO:
     Move global vars into singletons
     Move keyboard/mouse commands away from exec utilization (currently a limit of libs' argument handling)
     Optimize IRCv3 tag parses in utility
+    Bug: When wacky WASD is over, the 'done' message isn't sent.
 """
 
 #--------------------------------

--- a/main.py
+++ b/main.py
@@ -33,7 +33,6 @@ CheerCommand for Twitch
     0.1.4
         Fixed !wasd duration
     0.2.0
-
         Reworked command, action, and configuration
 
 http://twitch.tv/johnlonnie
@@ -76,33 +75,38 @@ commandCounter = 0
 
 #send to the socket
 def send(s, text):
+    """
+    Sends raw text to the given socket.
+
+    This does not send a chat message to the channel. Use :func:`chat` instead.
+    """
     s.send(text.encode('utf-8') + b'\r\n')
 
 #send chat message
 def chat(sock, msg):
+    """
+    Sends a chat message to the IRC channel the given socket is connected to.
 
-    #Send a chat message to the server.
-    #Keyword arguments:
-    #sock -- the socket over which to send the message
-    #msg  -- the message to be sent
-
+    :param sock: The socket over which to send the message
+    :param msg: The message to be sent
+    """
     sock.send(("PRIVMSG {} :{}\r\n".format(auth.CHAN, msg)).encode("UTF-8"))
 
 
 def trigger(bits: int, discount: bool = False):
     cmd = cmds.run(bits, discount=discount)
     if cmd is not None:
-        send(s, cmd.message)
+        chat(s, cmd.message)
 
 
 def trigger_random():
     cmd = cmds.run_random()
-    send(s, cmd.message)
+    chat(s, cmd.message)
 
 
 def wacky_wasd():
     cmd = cmds.run('wackywasd')
-    send(s, cmd.message)
+    chat(s, cmd.message)
 
 
 def randomPermit(twitchUser): #add user to random command permission list

--- a/pubg.csv
+++ b/pubg.csv
@@ -1,7 +1,0 @@
-100,50,You pressed R and probably made Lonnie reload.,keyboard,send,'r',,,
-150,75,You pressed Z and probably made Lonnie go prone.,keyboard,send,'z',,,
-200,100,You pressed 5 and switched to a throwable.,keyboard,send,'5',,,
-300,150,You pressed Left Mouse and probably made Lonnie shoot or honk.,mouse,click,button='left',,,
-500,250,You pressed Left Mouse for 3 seconds and probably made Lonnie unload a whole clip.,mouse,press,button='left',3,release
-800,400,You pressed E and probably made Lonnie exit a moving vehicle and die.,keyboard,send,'e',,,
-138,69,Dance Lonnie... Dance!,keyboard,send,';',,,

--- a/pubg.yml
+++ b/pubg.yml
@@ -49,7 +49,7 @@ commands:
     actions:
       - kind: keypress
         args: [;]
-  - name: wacky wasd
+  - name: wackywasd
     message: Wacky WASD!
     cost: 666
     discount: 333

--- a/pubg.yml
+++ b/pubg.yml
@@ -1,0 +1,58 @@
+---
+commands:
+  - name: reload
+    message: You pressed R and probably made Lonnie reload.
+    cost: 100
+    discount: 50
+    actions:
+      - kind: keypress
+        args: [r]
+  - name: prone
+    message: You pressed Z and probably made Lonnie go prone.
+    cost: 150
+    discount: 75
+    actions:
+      - kind: keypress
+        args: [z]
+  - name: nade out
+    message: You pressed 5 and switched to a throwable.
+    cost: 200
+    discount: 100
+    actions:
+      - kind: keypress
+        args: [5]
+  - name: shoot
+    message: You pressed Left Mouse and probably made Lonnie shoot or honk.
+    cost: 300
+    discount: 150
+    actions:
+      - kind: click
+        args: [left]
+  - name: empty clip
+    message: You pressed Left Mouse for 3 seconds and probably made Lonnie unload a whole clip.
+    cost: 500
+    discount: 250
+    actions:
+      - kind: click
+        args: [left, 3]
+  - name: e
+    message: You pressed E and probably made Lonnie exit a moving vehicle and die.
+    cost: 500
+    discount: 250
+    actions:
+      - kind: keypress
+        args: [e]
+  - name: dance
+    message: Dance Lonnie... Dance!
+    cost: 138
+    discount: 69
+    actions:
+      - kind: keypress
+        args: [;]
+  - name: wacky wasd
+    message: Wacky WASD!
+    cost: 666
+    discount: 333
+    actions:
+      - kind: wackywasd
+        args: [10]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ keyboard
 mouse
 attrs
 pyyaml
+
+# these are for tests, but it's just simpler to keep them in here
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+keyboard
+mouse
+attrs
+pyyaml

--- a/sot.csv
+++ b/sot.csv
@@ -1,4 +1,0 @@
-100,50,You pressed B and probably made Lonnie bucket,keyboard,send,'b',,,
-200,100,Cheers! You pressed 9 and probably made lonnie pull out his tankard.,keyboard,send,'9',,,
-300,150,You pressed Left Mouse and probably made Lonnie shoot or eat something he wasn't supposed to.,mouse,click,button='left',,,
-500,250,You pressed X and probably made lonnie drop something important or put away a weapon.,keyboard,send,'x',,,

--- a/sot.yml
+++ b/sot.yml
@@ -1,0 +1,30 @@
+---
+commands:
+  - name: bucket
+    message: You pressed B and probably made Lonnie bucket.
+    cost: 100
+    discount: 50
+    actions:
+      - kind: keypress
+        args: [b]
+  - name: tankard
+    message: Cheers! You pressed 9 and probably made Lonnie pull out his tankard.
+    cost: 200
+    discount: 100
+    actions:
+      - kind: keypress
+        args: ['9']
+  - name: shoot
+    message: You pressed Left Mouse and probably made Lonnie shoot or eat something he wasn't supposed to.
+    cost: 300
+    discount: 150
+    actions:
+      - kind: click
+        args: [left]
+  - name: drop
+    message: You pressed X and probably made Lonnie drop something important or put away a weapon.
+    cost: 500
+    discount: 250
+    actions:
+      - kind: keypress
+        args: [x]

--- a/special_types.py
+++ b/special_types.py
@@ -1,0 +1,5 @@
+""" Special types to reduce type annotation clutter. """
+from typing import Callable
+
+# A callable function reference that will send a message to chat.
+Chatter = Callable[[str], None]

--- a/test_actions.py
+++ b/test_actions.py
@@ -1,0 +1,58 @@
+import actions
+from actions import Action
+
+
+def test_loads_registry():
+    assert 'keypress' in actions._registry
+    assert 'click' in actions._registry
+    assert 'wait' in actions._registry
+    assert 'wackywasd' in actions._registry
+
+
+def test_keypress_with_duration():
+    a = Action.from_config({
+        'kind': 'keypress',
+        'args': ['a', 100],
+    })
+    assert isinstance(a, actions.KeyPress)
+    assert a.key == 'a'
+    assert a.duration_s == 100.0
+
+
+def test_keypress():
+    a = Action.from_config({
+        'kind': 'keypress',
+        'args': ['a'],
+    })
+    assert isinstance(a, actions.KeyPress)
+    assert a.key == 'a'
+    assert a.duration_s == 0.0
+
+
+def test_wait():
+    a = Action.from_config({
+        'kind': 'wait',
+        'args': [10.0],
+    })
+    assert isinstance(a, actions.Wait)
+    assert a.duration_s == 10.0
+
+
+def test_click_with_duration():
+    a = Action.from_config({
+        'kind': 'click',
+        'args': ['left', 0.45],
+    })
+    assert isinstance(a, actions.Click)
+    assert a.button == 'left'
+    assert a.duration_s == 0.45
+
+
+def test_click():
+    a = Action.from_config({
+        'kind': 'click',
+        'args': ['left'],
+    })
+    assert isinstance(a, actions.Click)
+    assert a.button == 'left'
+    assert a.duration_s == 0.0

--- a/test_cmds.py
+++ b/test_cmds.py
@@ -74,6 +74,12 @@ def test_run_name(normal_config):
     assert cmd is not None
 
 
+def test_run_name_no_match(normal_config):
+    cmds.from_config(normal_config)
+    cmd = cmds.run('zxczxczxczxczxc')
+    assert cmd is None
+
+
 @pytest.mark.parametrize('cost,discount,name', [
     (100, False, 'asd'),
     (50, True, 'asd'),

--- a/test_cmds.py
+++ b/test_cmds.py
@@ -1,0 +1,111 @@
+import pytest
+import yaml
+
+import actions
+import cmds
+
+
+@pytest.fixture
+def normal_config():
+    return yaml.safe_load("""
+    commands:
+      - name: asd
+        message: asdasdasd
+        cost: 100
+        discount: 50
+        actions:
+          - kind: wait
+            args: [0.05]
+      - name: zxc
+        message: zxczxczxc
+        cost: 200
+        discount: 100
+        actions:
+          - kind: wait
+            args: [0.01]
+          - kind: wait
+            args: [0.02]
+    """)
+
+
+def test_from_config(normal_config):
+    commands = cmds.from_config(normal_config)
+    cmd = commands['asd']
+    assert cmd.message == 'asdasdasd'
+    assert cmd.cost == 100
+    assert cmd.discount == 50
+    assert len(cmd._actions) == 1
+    assert isinstance(cmd._actions[0], actions.Wait)
+    assert cmd._actions[0].duration_s == 0.05
+    cmd = commands['zxc']
+    assert cmd.message == 'zxczxczxc'
+    assert cmd.cost == 200
+    assert cmd.discount == 100
+    assert len(cmd._actions) == 2
+    assert isinstance(cmd._actions[0], actions.Wait)
+    assert cmd._actions[0].duration_s == 0.01
+    assert isinstance(cmd._actions[1], actions.Wait)
+    assert cmd._actions[1].duration_s == 0.02
+
+
+def test_checks_collisions(normal_config):
+    cmd2 = normal_config['commands'][1]
+    # Same name should cause an error
+    cmd2['name'] = 'asd'
+    with pytest.raises(ValueError):
+        cmds.from_config(normal_config)
+    cmd2['name'] = 'zxc'
+
+    # Same cost should cause an error
+    cmd2['cost'] = 100
+    with pytest.raises(ValueError):
+        cmds.from_config(normal_config)
+    cmd2['cost'] = 200
+
+    # Same discount should cause an error
+    cmd2['discount'] = 50
+    with pytest.raises(ValueError):
+        cmds.from_config(normal_config)
+
+
+def test_run_name(normal_config):
+    cmds.from_config(normal_config)
+    cmd = cmds.run('asd')
+    assert cmd is not None
+
+
+@pytest.mark.parametrize('cost,discount,name', [
+    (100, False, 'asd'),
+    (50, True, 'asd'),
+    (200, False, 'zxc'),
+    (200, True, None),
+    (100, True, 'zxc'),
+    (123123123, False, None),
+    (123123123, True, None),
+])
+def test_run_index(normal_config, cost, discount, name):
+    cmds.from_config(normal_config)
+    cmd = cmds.run(cost, discount=discount)
+    if name is None:
+        assert cmd is None
+    else:
+        assert cmd.name == name
+
+
+@pytest.mark.parametrize('i,name', [
+    (0, 'asd'),
+    (-1, None),
+    (1, 'zxc'),
+    (40, None),
+])
+def test_get_nth(i, name):
+    cmd = cmds.get_nth(i)
+    if name is None:
+        assert cmd is None
+    else:
+        assert cmd.name == name
+
+
+def test_run_random():
+    cmd = cmds.run_random()
+    assert cmd.name in {'asd', 'zxc'}


### PR DESCRIPTION
It'll be best to read this change commit-by-commit. I tried to isolate changes for easier review.

This reworks commands and configuration:
- Use YAML instead of CSV (the actual format is trivial and can be removed from this change set and implemented separately, although these changes are harder to specify with CSV)
- Bits commands are composed of a sequence of actions (right now, commands only have one action, but this opens the possibility of having more) (eg. press 5, wait, left click, wait press z - to throw a nade and go prone in PubG)
- The config spec allows for arbitrary numbers of arguments passed to each action. As long as the action itself supports it, it can be used.
- Actions are lower level things like keyboard key presses, mouse button clicks, or anything really (including remapping keys for wacky WASD)
- Adds a requirements.txt file to simplify setup if this code is ever run somewhere else (people can just run `pip install -r requirements.txt`)

This will require the following new packages installed in the Python environment (hopefully a virtualenv):
- attrs
- pyyaml
(Or run `pip install -r requirements.txt`)

~This most likely overrides #1, since the WASD threading logic is built into the migrated action code in this PR.~